### PR TITLE
Add internet permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A [cookiecutter](https://github.com/audreyr/cookiecutter) :cookie: template for 
 - The latest version of [Gradle Build Tools](https://gradle.org/) :wrench:
 - The latest version of the [Android Support Library](https://developer.android.com/topic/libraries/support-library/index.html) :books:
 - Some of our favorite and most often used [dependencies](https://github.com/thoughtbot/android-template/blob/master/%7B%7B%20cookiecutter.repo_name%20%7D%7D/app/build.gradle#L30) :family:
+- Internet permission :earth_africa:
 - Configuration for [CircleCI](https://circleci.com) :large_blue_circle:
 
 ## Optional Dependencies

--- a/{{ cookiecutter.repo_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.repo_name }}/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="{{ cookiecutter.package_name }}">
 
+  <uses-permission android:name="android.permission.INTERNET" />
+
   <application
     android:allowBackup="true"
     android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## 🔧  changes
- Add manifest permission for internet
## ❓ why
- This is the easiest thing in the world to forget and is required for almost every single app
## 📝  other considerations or concerns
- Adding permissions without people being explicitly aware might not be great. But that's really a devil's advocate argument more than my real belief for this specific permission
