### PR TITLE
Bump version codes

### DIFF
--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -50,14 +50,14 @@ dependencies {
   //unit tests
   testCompile 'junit:junit:4.12'
   testCompile 'org.robolectric:robolectric:3.0'
-  testCompile 'org.mockito:mockito-core:1.10.5'
+  testCompile 'org.mockito:mockito-core:2.7.5'
   testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
   testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
   testCompile "com.nhaarman:mockito-kotlin:1.3.0"
 
   //automation tests
-  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-  androidTestCompile 'com.android.support.test:runner:0.5'
+  androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
+  androidTestCompile 'com.android.support.test:runner:1.0.1'
   androidTestCompile "com.android.support:support-annotations:${supportLibraryVersion}"
 
   //networking

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 ext {
-  supportLibraryVersion = '25.2.0'
+  supportLibraryVersion = '25.4.0'
 }
 
 dependencies {

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
   compileSdkVersion 25
-  buildToolsVersion "25.0.2"
+  buildToolsVersion "26.0.2"
   defaultConfig {
     applicationId "$application_id"
     minSdkVersion 19

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -31,7 +31,8 @@ android {
 }
 
 ext {
-  supportLibraryVersion = '25.4.0'
+  supportLibraryVersion = '27.0.1'
+  retrofitVersion = '2.1.0'
 }
 
 dependencies {
@@ -61,12 +62,12 @@ dependencies {
   androidTestCompile "com.android.support:support-annotations:${supportLibraryVersion}"
 
   //networking
-  compile 'com.squareup.retrofit2:retrofit:2.0.0'
-  compile 'com.squareup.retrofit2:converter-gson:2.0.0'
-  compile 'com.squareup.okhttp3:logging-interceptor:3.0.1'
+  compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
+  compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
   {% if cookiecutter.use_rx == 'yes' -%}
-  compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0'
+  compile "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
   {%- endif %}
+  compile 'com.squareup.okhttp3:logging-interceptor:3.0.1'
 
   //image caching and downloading
   compile 'com.squareup.picasso:picasso:2.5.2'

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-  compileSdkVersion 25
+  compileSdkVersion 27
   buildToolsVersion "26.0.2"
   defaultConfig {
     applicationId "$application_id"
     minSdkVersion 19
-    targetSdkVersion 25
+    targetSdkVersion 27
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
   {% if cookiecutter.use_rx == 'yes' -%}
   compile "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
   {%- endif %}
-  compile 'com.squareup.okhttp3:logging-interceptor:3.0.1'
+  compile 'com.squareup.okhttp3:logging-interceptor:3.5.0'
 
   //image caching and downloading
   compile 'com.squareup.picasso:picasso:2.5.2'

--- a/{{ cookiecutter.repo_name }}/build.gradle
+++ b/{{ cookiecutter.repo_name }}/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.0.6'
+  ext.kotlin_version = '1.1.51'
   repositories {
     jcenter()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.0.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
 

--- a/{{ cookiecutter.repo_name }}/build.gradle
+++ b/{{ cookiecutter.repo_name }}/build.gradle
@@ -19,5 +19,6 @@ buildscript {
 allprojects {
   repositories {
     jcenter()
+    google()
   }
 }

--- a/{{ cookiecutter.repo_name }}/gradle/wrapper/gradle-wrapper.properties
+++ b/{{ cookiecutter.repo_name }}/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
## :wrench: changes
- Bumped Kotlin version
- Bumped gradle version(s)
- Bumped dependency versions
- Bumped target/compile versions to O
- Extracted retrofit version code

## :question: why?
- To keep dependencies up to date
- To make the script play nicely with AS 3.0

## :memo: other considerations or concerns
- Should we bump the rxjava versions to use rxjava2?
- Generally not great to blindly update dependency versions, but the ones provided here are all pretty reliable. Thoughts?

