### PR TITLE
Update template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,6 @@
     "package_name": "com.{{cookiecutter.company_name | lower }}.{{ cookiecutter.project_name | lower }}",
     "package_path": "{{ cookiecutter.package_name | replace('.', '/') }}",
     "use_rx": "yes",
-    "use_custom_fonts": "yes",
 
     "_copy_without_render": [
         "gradlew",

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -36,52 +36,52 @@ ext {
 }
 
 dependencies {
-  compile fileTree(dir: 'libs', include: ['*.jar'])
+  implementation fileTree(dir: 'libs', include: ['*.jar'])
 
   //kotlin
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-  compile 'org.jetbrains.anko:anko-common:0.8.3'
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+  implementation 'org.jetbrains.anko:anko-common:0.8.3'
 
   //android
-  compile "com.android.support:appcompat-v7:${supportLibraryVersion}"
-  compile "com.android.support:design:${supportLibraryVersion}"
-  compile "com.android.support:recyclerview-v7:${supportLibraryVersion}"
+  implementation "com.android.support:appcompat-v7:${supportLibraryVersion}"
+  implementation "com.android.support:design:${supportLibraryVersion}"
+  implementation "com.android.support:recyclerview-v7:${supportLibraryVersion}"
 
   //unit tests
-  testCompile 'junit:junit:4.12'
-  testCompile 'org.robolectric:robolectric:3.0'
-  testCompile 'org.mockito:mockito-core:2.7.5'
-  testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-  testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-  testCompile "com.nhaarman:mockito-kotlin:1.3.0"
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.robolectric:robolectric:3.0'
+  testImplementation 'org.mockito:mockito-core:2.7.5'
+  testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+  testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+  testImplementation "com.nhaarman:mockito-kotlin:1.3.0"
 
   //automation tests
-  androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
-  androidTestCompile 'com.android.support.test:runner:1.0.1'
-  androidTestCompile "com.android.support:support-annotations:${supportLibraryVersion}"
+  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+  androidTestImplementation 'com.android.support.test:runner:1.0.1'
+  androidTestImplementation "com.android.support:support-annotations:${supportLibraryVersion}"
 
   //networking
-  compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
-  compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+  implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+  implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
   {% if cookiecutter.use_rx == 'yes' -%}
-  compile "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
+  implementation "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
   {%- endif %}
-  compile 'com.squareup.okhttp3:logging-interceptor:3.5.0'
+  implementation 'com.squareup.okhttp3:logging-interceptor:3.5.0'
 
   //image caching and downloading
-  compile 'com.squareup.picasso:picasso:2.5.2'
+  implementation 'com.squareup.picasso:picasso:2.5.2'
 
   {% if cookiecutter.use_rx == 'yes' -%}
   //rx
-  compile 'io.reactivex:rxjava:1.1.6'
-  compile 'io.reactivex:rxandroid:1.1.0'
-  compile 'com.jakewharton.rxbinding:rxbinding-recyclerview-v7:0.4.0'
+  implementation 'io.reactivex:rxjava:1.1.6'
+  implementation 'io.reactivex:rxandroid:1.1.0'
+  implementation 'com.jakewharton.rxbinding:rxbinding-recyclerview-v7:0.4.0'
   {%- endif %}
 
 
   {% if cookiecutter.use_custom_fonts == 'yes' -%}
   //custom fonts
-  compile 'uk.co.chrisjenx:calligraphy:2.1.0'
+  implementation 'uk.co.chrisjenx:calligraphy:2.1.0'
   {%- endif %}
 }

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -4,10 +4,10 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "26.0.2"
+  buildToolsVersion "27.0.3"
   defaultConfig {
     applicationId "$application_id"
-    minSdkVersion 19
+    minSdkVersion 21
     targetSdkVersion 27
     versionCode 1
     versionName "1.0"
@@ -31,7 +31,7 @@ android {
 }
 
 ext {
-  supportLibraryVersion = '27.0.1'
+  supportLibraryVersion = '27.1.1'
   retrofitVersion = '2.1.0'
 }
 
@@ -51,14 +51,14 @@ dependencies {
   //unit tests
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.robolectric:robolectric:3.0'
-  testImplementation 'org.mockito:mockito-core:2.7.5'
+  testImplementation 'org.mockito:mockito-core:2.19.0'
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
   testImplementation "com.nhaarman:mockito-kotlin:1.3.0"
 
   //automation tests
-  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-  androidTestImplementation 'com.android.support.test:runner:1.0.1'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+  androidTestImplementation 'com.android.support.test:runner:1.0.2'
   androidTestImplementation "com.android.support:support-annotations:${supportLibraryVersion}"
 
   //networking
@@ -67,14 +67,14 @@ dependencies {
   {% if cookiecutter.use_rx == 'yes' -%}
   implementation "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
   {%- endif %}
-  implementation 'com.squareup.okhttp3:logging-interceptor:3.5.0'
+  implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
 
   //image caching and downloading
-  implementation 'com.squareup.picasso:picasso:2.5.2'
+  implementation 'com.squareup.picasso:picasso:2.71828'
 
   {% if cookiecutter.use_rx == 'yes' -%}
   //rx
-  implementation 'io.reactivex:rxjava:1.1.6'
+  implementation 'io.reactivex:rxjava:1.2.1'
   implementation 'io.reactivex:rxandroid:1.1.0'
   implementation 'com.jakewharton.rxbinding:rxbinding-recyclerview-v7:0.4.0'
   {%- endif %}

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -32,7 +32,7 @@ android {
 
 ext {
   supportLibraryVersion = '27.1.1'
-  retrofitVersion = '2.1.0'
+  retrofitVersion = '2.4.0'
 }
 
 dependencies {
@@ -50,11 +50,9 @@ dependencies {
 
   //unit tests
   testImplementation 'junit:junit:4.12'
-  testImplementation 'org.robolectric:robolectric:3.0'
-  testImplementation 'org.mockito:mockito-core:2.19.0'
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-  testImplementation "com.nhaarman:mockito-kotlin:1.3.0"
+  testImplementation "io.mockk:mockk:1.8.7"
 
   //automation tests
   androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
@@ -65,7 +63,7 @@ dependencies {
   implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
   implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
   {% if cookiecutter.use_rx == 'yes' -%}
-  implementation "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
+  implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
   {%- endif %}
   implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
 
@@ -74,8 +72,8 @@ dependencies {
 
   {% if cookiecutter.use_rx == 'yes' -%}
   //rx
-  implementation 'io.reactivex:rxjava:1.2.1'
-  implementation 'io.reactivex:rxandroid:1.1.0'
-  implementation 'com.jakewharton.rxbinding:rxbinding-recyclerview-v7:0.4.0'
+  implementation "io.reactivex.rxjava2:rxjava:2.2.2"
+  implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
+  implementation 'com.jakewharton.rxbinding2:rxbinding-recyclerview-v7:2.1.1'
   {%- endif %}
 }

--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -78,10 +78,4 @@ dependencies {
   implementation 'io.reactivex:rxandroid:1.1.0'
   implementation 'com.jakewharton.rxbinding:rxbinding-recyclerview-v7:0.4.0'
   {%- endif %}
-
-
-  {% if cookiecutter.use_custom_fonts == 'yes' -%}
-  //custom fonts
-  implementation 'uk.co.chrisjenx:calligraphy:2.1.0'
-  {%- endif %}
 }

--- a/{{ cookiecutter.repo_name }}/build.gradle
+++ b/{{ cookiecutter.repo_name }}/build.gradle
@@ -1,13 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.1.51'
+  ext.kotlin_version = '1.2.70'
   repositories {
     jcenter()
+    google()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0'
+    classpath 'com.android.tools.build:gradle:3.1.4'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
 

--- a/{{ cookiecutter.repo_name }}/gradle/wrapper/gradle-wrapper.properties
+++ b/{{ cookiecutter.repo_name }}/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 03 12:03:03 PDT 2017
+#Fri Sep 14 14:17:09 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
## :wrench: changes
- Update versions of Gradle, Kotlin, and several libraries
- Target new version of Android
- Bump the minSdk in accordance with the [one true source](https://twitter.com/minsdkversion) of what your minSdk should be: 
- Remove roboelectric
- Remove Mockito in favor of mockk
- Remove Calligraphy in favor of using Androids new build in font styling
## :question: why?
- Version upgrading needs no explanation
- The more contentious changes have to do with testing. I removed roboelectric because I have not found it to be useful since the android architecture components have been introduced and I've found its use to be a particularly bad code smell nowadays. Anytime we need to test things that interact with Android we can use androidTests, and any time we have things that we want to unit test that would require roboelectric its a good sign that we should instead refactor the code.
- I removed Mockito in favor of Mockk. Mockito has [many](https://github.com/nhaarman/mockito-kotlin/issues/285) [issues](https://github.com/mockito/mockito/issues/1481) when integrating with Kotlin, and the API is clearly designed for Java. Mockk, while still (somewhat) early in its development, is much more Kotlin focused and resolves many of the issues Mockito has.
