### PR TITLE
Add staging vs debug vs production distinctions

### DIFF
--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -18,6 +18,13 @@ android {
       minifyEnabled false
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
+    debug {
+      applicationIdSuffix ".debug"
+    }
+    staging {
+      applicationIdSuffix ".staging"
+      signingConfig signingConfigs.debug
+    }
   }
 
   lintOptions {

--- a/{{ cookiecutter.repo_name }}/app/src/debug/res/values/strings.xml
+++ b/{{ cookiecutter.repo_name }}/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">{{ cookiecutter.project_name }}-debug</string>
+</resources>

--- a/{{ cookiecutter.repo_name }}/app/src/staging/res/values/strings.xml
+++ b/{{ cookiecutter.repo_name }}/app/src/staging/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">{{ cookiecutter.project_name }}-staging</string>
+</resources>


### PR DESCRIPTION

## :wrench: changes
- Add build types for staging and debug
- Set different application ids for staging and debug
- Add different application names for staging and debug

## :question: why?
- Most android apps we build create a distinction between production and staging applications. It's helpful to be able to distinguish if an app is a debug build, a staging build, or a production build out in the wild. It's also helpful to be able to have staging and production builds installed together.


